### PR TITLE
업데이트시 변동된 파일만 다운로드

### DIFF
--- a/lib/utilities/hive_name.dart
+++ b/lib/utilities/hive_name.dart
@@ -6,6 +6,7 @@ class HiveName {
   static const String subscribeBoxName = "subscribeBox";
 
   static const String localCommitDateKey = "localCommitDate";
+  static const String localCommitHashKey = "localCommitHash";
   static const String serverCommitDateKey = "serverCommitDate";
   static const String githubTokenKey = "githubToken";
   static const String appThemeIndexKey = "appThemeIndex";

--- a/lib/widgets/setting/setting_update_view.dart
+++ b/lib/widgets/setting/setting_update_view.dart
@@ -74,17 +74,22 @@ class SettingUpdateView extends StatelessWidget {
   }
 
   void showUpdateDialog() {
+    bool updateNeeds = IntlUtil.needUpdate(nendoController.serverCommitDate, nendoController.localCommitDate);
     Get.dialog(
       CommonDialog(
         title: "DB 업데이트",
-        content: IntlUtil.needUpdate(nendoController.serverCommitDate, nendoController.localCommitDate)
-            ? "DB 업데이트를 진행하시겠습니까?\n모든 데이터를 다시 받기때문에 시간이 다소 소요되며 다운로드 도중 앱 종료시 저장된 데이터가 삭제될 수 있습니다."
+        content: updateNeeds
+            ? "DB 업데이트를 진행하시겠습니까?\n다운로드 도중 앱 종료시 저장된 데이터가 삭제될 수 있습니다."
             : "이미 최신버전입니다.\n강제 업데이트를 진행할까요?",
         negativeText: "취소",
         positiveOnClick: () {
           Get.find<DashboardController>().tabIndex = 0;
           nendoController.backupData();
-          nendoController.fetchData();
+          if (updateNeeds && nendoController.localCommitHash != "null") {
+            nendoController.updateDB();                  
+          } else {
+            nendoController.fetchData();
+          }
         },
       ),
     );


### PR DESCRIPTION
DB 업데이트때 마다 모든 파일을 다시 다운받는것은 비효율적임. 따라서 커밋 해시 기반으로 변동된 파일만 업데이트 하는 기능을 추가했습니다.

기존 사용자의 경우 다운로드된 상태의 커밋 해시를 모르기에 최초에 한해 기존처럼 전체 다운로드를 수행합니다.

P.S. Flutter하고 Dart를 써본적이 없어서 코드 상태가 영 엉망일수 있으나 기능은 정상 작동하는걸로 보입니다